### PR TITLE
Potential issue in src/indexer.c: Unchecked return from initialization function

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -261,7 +261,7 @@ static int store_object(git_indexer *idx)
 {
 	int i, error;
 	khiter_t k;
-	git_oid oid;
+	git_oid oid = {};
 	struct entry *entry;
 	git_off_t entry_size;
 	struct git_pack_entry *pentry;
@@ -886,7 +886,7 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 	struct git_pack_idx_header hdr;
 	git_buf filename = GIT_BUF_INIT;
 	struct entry *entry;
-	git_oid trailer_hash, file_hash;
+	git_oid trailer_hash = {}, file_hash;
 	git_hash_ctx ctx;
 	git_filebuf index_file = {0};
 	void *packfile_trailer;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**2 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `src/indexer.c` 
Enclosing Function : `store_object`
Function : `git_hash_final` 
https://github.com/siva-msft/libgit2/blob/53d0ba4625cc355f03d925ec26fc92310dd89fee/src/indexer.c#L277
**Issue in**: _oid_

**Code extract**:

```cpp
	pentry = git__calloc(1, sizeof(struct git_pack_entry));
	GITERR_CHECK_ALLOC(pentry);

	git_hash_final(&oid, ctx); <------ HERE
	entry_size = idx->off - entry_start;
	if (entry_start > UINT31_MAX) {
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `src/indexer.c` 
Enclosing Function : `git_indexer_commit`
Function : `git_hash_final` 
https://github.com/siva-msft/libgit2/blob/53d0ba4625cc355f03d925ec26fc92310dd89fee/src/indexer.c#L913
**Issue in**: _trailer_hash_

**Code extract**:

```cpp
	git_oid_fromraw(&file_hash, packfile_trailer);
	git_mwindow_close(&w);

	git_hash_final(&trailer_hash, &idx->trailer); <------ HERE
	if (git_oid_cmp(&file_hash, &trailer_hash)) {
		giterr_set(GITERR_INDEXER, "packfile trailer mismatch");
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
